### PR TITLE
モバイル表示のサブタイトルが崩れる部分を修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -316,6 +316,10 @@ export default Vue.extend({
   @include lessThan($tiny) {
     width: 100px;
   }
+
+  @media screen and (max-width: 480px) {
+    width: 10rem;
+  }
 }
 
 .SideNavigation-HeaderText {
@@ -326,6 +330,11 @@ export default Vue.extend({
 
   @include lessThan($tiny) {
     margin: 0;
+  }
+
+  @media screen and (max-width: 480px) {
+    margin-left: 0;
+    font-size: 0.7rem;
   }
 }
 


### PR DESCRIPTION
##  👏 解決する issue / Resolved Issues
- close #0
- close #0

## 📝 関連する issue / Related Issues
- #23
- #23

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- モバイル表示のサブタイトルが崩れる部分を修正

## 📸 スクリーンショット / Screenshots
![fix](https://user-images.githubusercontent.com/30864536/77387216-259ea300-6dd0-11ea-8d5c-7a08805c4100.png)
