### PR TITLE
オープンデータカタログサイト/Githubのリンクを東京都から青森県のものに修正

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -177,7 +177,7 @@
         path="本サイトで公表しているデータは、{catalogWebsite}より誰でも自由にダウンロードが可能です。（データは順次追加予定です）"
       >
         <a
-          href="https://portal.data.metro.tokyo.lg.jp/"
+          href="https://opendata.pref.aomori.lg.jp/"
           target="_blank"
           rel="noopener"
           place="catalogWebsite"
@@ -196,7 +196,7 @@
         }}
         <i18n path="詳しくは、{githubRepo}をご確認ください。">
           <a
-            href="https://github.com/tokyo-metropolitan-gov/covid19"
+            href="https://github.com/covid19-aomori/website"
             target="_blank"
             rel="noopener"
             place="githubRepo"


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #16

## ⛏ 変更内容 / Details of Changes
- about ページのオープンデータカタログサイト/Githubのリンクを東京都から青森県のものに修正
