### PR TITLE
#47 解決: 【有志作成版】の表記箇所を修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -16,8 +16,8 @@
             :alt="$t('青森県')"
           />
           <div class="SideNavigation-HeaderText">
-            {{ $t('menu/新型コロナウイルス感染症') }}<br />{{
-              $t('menu/対策サイト')
+            {{ $t('新型コロナウイルス感染症') }}<br />{{
+              $t('対策サイト【有志作成版】')
             }}
           </div>
         </nuxt-link>
@@ -145,7 +145,7 @@ export default Vue.extend({
       return [
         {
           icon: 'mdi-chart-timeline-variant',
-          title: this.$t('県内の最新感染動向【有志作成版】'),
+          title: this.$t('県内の最新感染動向'),
           link: this.localePath('/')
         },
         // {
@@ -328,6 +328,8 @@ export default Vue.extend({
 
 .SideNavigation-HeaderText {
   margin: 10px 0 0 0;
+  text-align: center;
+
   @include lessThan($small) {
     margin: 0 0 0 10px;
   }
@@ -338,6 +340,7 @@ export default Vue.extend({
 
   @media screen and (max-width: 480px) {
     margin-left: 0;
+    text-align: left;
     font-size: 0.7rem;
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -81,7 +81,7 @@ export default Vue.extend({
       Data,
       headerItem: {
         icon: 'mdi-chart-timeline-variant',
-        title: this.$t('県内の最新感染動向【有志作成版】')
+        title: this.$t('県内の最新感染動向')
       },
       newsItems: News.newsItems
     }
@@ -94,7 +94,7 @@ export default Vue.extend({
   },
   head(): MetaInfo {
     return {
-      title: this.$t('県内の最新感染動向【有志作成版】') as string
+      title: this.$t('県内の最新感染動向') as string
     }
   }
 })


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #47

## ⛏ 変更内容 / Details of Changes
- コンテンツのヘッダから【有志作成版】を削除し、サイドナビゲーションのサブタイトルに追加

## 📸 スクリーンショット / Screenshots
### PC
![fix01](https://user-images.githubusercontent.com/30864536/77488227-f5124400-6e77-11ea-8b64-757fc4b0ef9d.png)

### モバイル
![fix02](https://user-images.githubusercontent.com/30864536/77488231-f80d3480-6e77-11ea-8503-0f458685722b.png)
