### PR TITLE
サイドナビゲーションの順番を「当サイトについて」が一番上に来るように修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -181,12 +181,12 @@ export default Vue.extend({
         //     'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event00.html'
         // },
         {
-          title: this.$t('知事からのメッセージ'),
-          link: 'https://www.pref.aomori.lg.jp/koho/R020228message.html'
-        },
-        {
           title: this.$t('当サイトについて'),
           link: this.localePath('/about')
+        },
+        {
+          title: this.$t('知事からのメッセージ'),
+          link: 'https://www.pref.aomori.lg.jp/koho/R020228message.html'
         },
         // {
         //   title: this.$t('お問い合わせ先一覧'),


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #48 

## ⛏ 変更内容 / Details of Changes
- サイドナビゲーションの順番を「当サイトについて」が一番上に来るように修正