### PR TITLE
「陽性患者の属性」カードに情報元へのリンクを追加 #76

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -13,7 +13,13 @@
       :fixed-header="true"
       :mobile-breakpoint="0"
       class="cardTable"
-    />
+    >
+      <template v-slot:item.source="{ item }">
+        <a v-if="item.source" :href="item.source" target="_blank" rel="noopener"
+          >リンク</a
+        >
+      </template>
+    </v-data-table>
     <div class="note">
       {{ $t('※退院には、死亡退院を含む') }}
     </div>

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -42,12 +42,15 @@ export default {
     for (const header of patientsTable.headers) {
       header.text =
         header.value === '退院' ? this.$t('退院※') : this.$t(header.value)
+      header.text =
+        header.value === 'source' ? this.$t('情報元') : this.$t(header.value)
     }
     // 陽性患者の属性 中身の翻訳
     for (const row of patientsTable.datasets) {
       row['居住地'] = this.$t(row['居住地'])
       row['性別'] = this.$t(row['性別'])
       row['退院'] = this.$t(row['退院'])
+      row.source = this.$t(row.source)
 
       if (row['年代'] === '10歳未満') {
         row['年代'] = this.$t('10歳未満')

--- a/data/data.json
+++ b/data/data.json
@@ -39,7 +39,8 @@
                 "年代": "70代",
                 "性別": "男性",
                 "退院": null,
-                "date": "2020-03-23"
+                "date": "2020-03-23",
+                "source": "https://www.pref.aomori.lg.jp/soshiki/kenko/hoken/files/200323press.pdf"
             },
             {
                 "リリース日": "2020-03-23T09:00:00.000Z",
@@ -47,7 +48,8 @@
                 "年代": "70代",
                 "性別": "女性",
                 "退院": null,
-                "date": "2020-03-23"
+                "date": "2020-03-23",
+                "source": "https://www.pref.aomori.lg.jp/soshiki/kenko/hoken/files/200323press.pdf"
             },
             {
                 "リリース日": "2020-03-25T09:00:00.000Z",
@@ -55,7 +57,8 @@
                 "年代": "60代",
                 "性別": "男性",
                 "退院": null,
-                "date": "2020-03-25"
+                "date": "2020-03-25",
+                "source": "https://www.pref.aomori.lg.jp/soshiki/kenko/hoken/files/200325press.pdf"
             },
             {
                 "リリース日": "2020-03-25T09:00:00.000Z",
@@ -63,7 +66,8 @@
                 "年代": "60代",
                 "性別": "女性",
                 "退院": null,
-                "date": "2020-03-25"
+                "date": "2020-03-25",
+                "source": "https://www.pref.aomori.lg.jp/soshiki/kenko/hoken/files/200325press.pdf"
             },
             {
                 "リリース日": "2020-03-25T09:00:00.000Z",
@@ -71,7 +75,8 @@
                 "年代": "70代",
                 "性別": "女性",
                 "退院": null,
-                "date": "2020-03-25"
+                "date": "2020-03-25",
+                "source": "https://www.pref.aomori.lg.jp/soshiki/kenko/hoken/files/200325press.pdf"
             },
             {
                 "リリース日": "2020-03-25T09:00:00.000Z",
@@ -79,7 +84,8 @@
                 "年代": "70代",
                 "性別": "女性",
                 "退院": null,
-                "date": "2020-03-25"
+                "date": "2020-03-25",
+                "source": "https://www.pref.aomori.lg.jp/soshiki/kenko/hoken/files/200325press.pdf"
             },
             {
                 "リリース日": "2020-03-28T09:00:00.000Z",
@@ -87,7 +93,8 @@
                 "年代": "30代",
                 "性別": "女性",
                 "退院": null,
-                "date": "2020-03-28"
+                "date": "2020-03-28",
+                "source": "https://www.pref.aomori.lg.jp/soshiki/kenko/hoken/files/200328press.pdf"
             }
         ]
     },

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -5,7 +5,8 @@ const headers = [
   { text: '居住地', value: '居住地' },
   { text: '年代', value: '年代' },
   { text: '性別', value: '性別' },
-  { text: '退院※', value: '退院', align: 'center' }
+  { text: '退院※', value: '退院', align: 'center' },
+  { text: '情報元', value: 'source' }
 ]
 
 type DataType = {
@@ -14,6 +15,7 @@ type DataType = {
   年代: string | null
   性別: '男性' | '女性' | string
   退院: '◯' | null
+  source: string | null
   [key: string]: any
 }
 
@@ -23,6 +25,7 @@ type TableDataType = {
   年代: DataType['年代']
   性別: DataType['性別'] | '不明'
   退院: DataType['退院']
+  source: DataType['source']
 }
 
 type TableDateType = {
@@ -46,7 +49,8 @@ export default (data: DataType[]) => {
       居住地: d['居住地'] ?? '不明',
       年代: d['年代'] ?? '不明',
       性別: d['性別'] ?? '不明',
-      退院: d['退院']
+      退院: d['退院'],
+      source: d.source ?? ''
     }
     tableDate.datasets.push(TableRow)
   })


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #76 

## ⛏ 変更内容 / Details of Changes
- 「陽性患者の属性」カードに情報元カラムを追加し、青森県庁のPDFへのリンクを貼る

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-29 8 47 22](https://user-images.githubusercontent.com/10470863/77836494-f1ddc780-7199-11ea-8949-950622b8bbe8.png)

