### PR TITLE
「検査実施件数」に注釈追加と「日別」ボタンを非表示

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    class="TimeStackedBarChart"
+  >
     <template v-slot:button>
       <ul :class="$style.GraphDesc">
         <li>
@@ -17,6 +22,13 @@
         </li>
         <li>
           {{ $t('（注）3/23の件数はそれまでの累計です') }}
+        </li>
+        <li>
+          {{
+            $t(
+              '（注）青森県の発表日基準でのグラフとなるため土日などはまとめて週明けにカウントされます'
+            )
+          }}
         </li>
       </ul>
       <data-selector
@@ -56,6 +68,14 @@
     </template>
   </data-view>
 </template>
+
+<style lang="scss">
+.TimeStackedBarChart {
+  .DataSelector button:first-child {
+    display: none !important;
+  }
+}
+</style>
 
 <script lang="ts">
 import Vue from 'vue'
@@ -188,7 +208,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     }
   },
   data: () => ({
-    dataKind: 'transition',
+    dataKind: 'cumulative',
     canvas: true
   }),
   computed: {


### PR DESCRIPTION
## 📝 関連issue / Related Issues
#83

## ⛏ 変更内容 / Details of Changes
- 注釈「青森県の発表日基準でのグラフとなるため土日などはまとめて週明けにカウントされます」を追加
- 「日別」ボタンを非表示
  - CSS で完結させるためにクラスを追加し、その中で該当の要素を非表示にした

## 📸 スクリーンショット / Screenshots
<img width="598" alt="スクリーンショット 2020-03-30 22 26 43" src="https://user-images.githubusercontent.com/13248811/77921104-47b98900-72da-11ea-91c5-4afb9a1493a0.png">

