### PR TITLE
公式ホームページから新型コロナウイルス感染症についての情報へリンクを変更

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -201,8 +201,8 @@ export default Vue.extend({
         //   link: this.localePath('/contacts')
         // },
         {
-          title: this.$t('青森県公式ホームページ'),
-          link: 'https://www.pref.aomori.lg.jp/index.html'
+          title: this.$t('青森県からの新型コロナウイルス感染症についての情報'),
+          link: 'https://www.pref.aomori.lg.jp/koho/coronavirus_index.html'
         },
         {
           title: this.$t('各市区町村のリンク'),


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #102 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- サイドメニューの「青森県公式ホームページ」のリンクを「青森県からの新型コロナウイルス感染症についての情報」に変更

## 📸 スクリーンショット / Screenshots
